### PR TITLE
Fixed socket server client connection

### DIFF
--- a/bridge/src/main/java/com/bridge/core/handlers/LogHandler.java
+++ b/bridge/src/main/java/com/bridge/core/handlers/LogHandler.java
@@ -34,4 +34,8 @@ public class LogHandler {
     public static void log(Level level, String message) {
         logger.log(level, message);
     }
+
+    public static void log(Level level, String message, Throwable e) {
+        logger.log(level, message, e);
+    }
 }

--- a/bridge/src/main/java/com/bridge/ipc/SocketServer.java
+++ b/bridge/src/main/java/com/bridge/ipc/SocketServer.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedByInterruptException;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
@@ -18,17 +18,18 @@ import java.util.logging.Level;
  * and processes messages using a {@link Receiver}.
  */
 public class SocketServer implements Runnable {
+    private static final Path NAMESPACE =
+            Path.of(System.getProperty("java.io.tmpdir"), "events-socket.sock");
     private final Receiver receiver;
     private final Path namespace;
     private final AtomicBoolean isServerRunning;
-    private static final Path NAMESPACE =
-            Path.of(System.getProperty("java.io.tmpdir"), "events-socket.sock");
 
     /**
      * Constructs a {@code SocketServer} with the specified receiver and namespace.
      *
-     * @param receiver  the receiver to handle incoming messages
-     * @param namespace the namespace for the UNIX domain socket
+     * @param receiver        the receiver to handle incoming messages
+     * @param namespace       the namespace for the UNIX domain socket
+     * @param isServerRunning the atomic boolean to control the server running state
      */
     public SocketServer(Receiver receiver, Path namespace, AtomicBoolean isServerRunning) {
         this.receiver = receiver;
@@ -45,33 +46,15 @@ public class SocketServer implements Runnable {
         UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(namespace);
         try (ServerSocketChannel server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)) {
             server.bind(socketAddress);
-            LogHandler.log(Level.INFO, String.format("Listening on %s", namespace));
-            ByteBuffer buffer = ByteBuffer.allocate(1024);
-            server.configureBlocking(false);
-            while (isServerRunning.get()) {
-                try {
-                    SocketChannel client = server.accept();
-                    if (client != null) {
-                        buffer.clear();
-                        int bytesRead = client.read(buffer);
-                        if (bytesRead < 0) {
-                            LogHandler.log(Level.INFO, "Got empty message");
-                            continue;
-                        }
-                        buffer.rewind();
-                        receiver.handleMessage(buffer);
-                    }
-                    Thread.sleep(100);
-                } catch (ClosedByInterruptException | InterruptedException e) {
-                    LogHandler.log(Level.SEVERE, "SocketServer has been interrupted.");
-                }
-            }
-            flush();
-            LogHandler.log(Level.INFO, "Stopped SocketServer");
-
+            listen(server);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LogHandler.log(Level.SEVERE, "Socket Server has been interrupted", e);
+        } catch (ClosedChannelException e) {
+            LogHandler.log(Level.SEVERE, "Socket Server channel has been closed", e);
         } catch (IOException e) {
-            // TODO: Handle error
-            e.printStackTrace();
+            LogHandler.log(Level.SEVERE, "Unexpected exception", e);
+        } finally {
             flush();
         }
     }
@@ -79,15 +62,48 @@ public class SocketServer implements Runnable {
     /**
      * Cleans up the UNIX domain socket namespace by deleting the namespace file.
      */
-    public void flush() {
+    private void flush() {
         try {
             Files.deleteIfExists(namespace);
+            LogHandler.log(Level.INFO, String.format("Deleted namespace %s", namespace));
         } catch (IOException e) {
             LogHandler.log(
-                    Level.WARNING,
-                    String.format(
-                            "Could not remove namespace: %s\nBecause of %s",
-                            namespace, e.getMessage()));
+                    Level.SEVERE, String.format("Could not delete namespace %s", namespace), e);
+        }
+    }
+
+    /**
+     * Listens for incoming client connections and handles them.
+     *
+     * @param server the server socket channel to listen on
+     */
+    private void listen(ServerSocketChannel server) throws IOException, InterruptedException {
+        LogHandler.log(Level.INFO, String.format("Listening on %s", namespace));
+        while (isServerRunning.get()) {
+            try (SocketChannel channel = server.accept()) {
+                LogHandler.log(Level.INFO, String.format("Accepted client %s", channel));
+                manageChannel(channel);
+            }
+        }
+    }
+
+    /**
+     * Manages the communication channel with a client, reading messages and passing them to the receiver.
+     *
+     * @param channel the client socket channel to manage
+     */
+    private void manageChannel(SocketChannel channel) throws IOException, InterruptedException {
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        while (channel.isOpen() && isServerRunning.get()) {
+            buffer.clear();
+            int bytesRead = channel.read(buffer);
+            if (bytesRead <= 0) {
+                LogHandler.log(Level.INFO, "Nothing to read");
+                Thread.sleep(100);
+                continue;
+            }
+            buffer.flip();
+            receiver.handleMessage(buffer);
         }
     }
 }

--- a/bridge/src/test/java/com/bridge/ipc/SocketServerTest.java
+++ b/bridge/src/test/java/com/bridge/ipc/SocketServerTest.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
@@ -51,15 +52,20 @@ class SocketServerTest {
         }
     }
 
+    public static Receiver makeReceiver(KeyboardEventManager keyboardEventManager, MouseEventManager mouseEventManager){
+        Receiver receiver = new Receiver();
+        receiver.addBuffer(keyboardEventManager);
+        receiver.addBuffer(mouseEventManager);
+        return receiver;
+    }
+
+
     @Test
     void checkCompleteEventIsReceived() {
         KeyboardEventManager keyboardEventManager = new KeyboardEventManager();
         MouseEventManager mouseEventManager = new MouseEventManager();
-        Receiver receiver = new Receiver();
-        receiver.addBuffer(keyboardEventManager);
-        receiver.addBuffer(mouseEventManager);
         AtomicBoolean atomicBoolean = new AtomicBoolean(true);
-        Thread thread = startServer(receiver, atomicBoolean);
+        Thread thread = startServer(makeReceiver(keyboardEventManager, mouseEventManager), atomicBoolean);
 
         sendToServer(new EventGenerator().makeEvent());
         for (int i = 0; i < 3; i++) {
@@ -75,7 +81,10 @@ class SocketServerTest {
 
         atomicBoolean.set(false);
         try {
-            thread.join();
+            thread.join(100);
+            if (thread.isAlive()){
+                thread.interrupt();
+            }
         } catch (InterruptedException e) {
             e.printStackTrace();
             fail("Failed to join server thread: " + e.getMessage());
@@ -89,11 +98,8 @@ class SocketServerTest {
     void checkSocketHandlesEmptyBuffer() {
         KeyboardEventManager keyboardEventManager = new KeyboardEventManager();
         MouseEventManager mouseEventManager = new MouseEventManager();
-        Receiver receiver = new Receiver();
-        receiver.addBuffer(keyboardEventManager);
-        receiver.addBuffer(mouseEventManager);
         AtomicBoolean atomicBoolean = new AtomicBoolean(true);
-        Thread thread = startServer(receiver, atomicBoolean);
+        Thread thread = startServer(makeReceiver(keyboardEventManager, mouseEventManager), atomicBoolean);
 
         sendToServer(ByteBuffer.allocate(0));
         for (int i = 0; i < 3; i++) {
@@ -108,7 +114,10 @@ class SocketServerTest {
 
         atomicBoolean.set(false);
         try {
-            thread.join();
+            thread.join(100);
+            if (thread.isAlive()){
+                thread.interrupt();
+            }
         } catch (InterruptedException e) {
             e.printStackTrace();
             fail("Failed to join server thread: " + e.getMessage());
@@ -122,11 +131,8 @@ class SocketServerTest {
     void checkOnlyKeyboardEvent() {
         KeyboardEventManager keyboardEventManager = new KeyboardEventManager();
         MouseEventManager mouseEventManager = new MouseEventManager();
-        Receiver receiver = new Receiver();
-        receiver.addBuffer(keyboardEventManager);
-        receiver.addBuffer(mouseEventManager);
         AtomicBoolean atomicBoolean = new AtomicBoolean(true);
-        Thread thread = startServer(receiver, atomicBoolean);
+        Thread thread = startServer(makeReceiver(keyboardEventManager, mouseEventManager), atomicBoolean);
 
         sendToServer(new EventGenerator().makeKeyboardOnlyEvent());
         for (int i = 0; i < 3; i++) {
@@ -141,7 +147,10 @@ class SocketServerTest {
 
         atomicBoolean.set(false);
         try {
-            thread.join();
+            thread.join(100);
+            if (thread.isAlive()){
+                thread.interrupt();
+            }
         } catch (InterruptedException e) {
             e.printStackTrace();
             fail("Failed to join server thread: " + e.getMessage());
@@ -154,13 +163,10 @@ class SocketServerTest {
     void checkOnlyMouseEvent() {
         KeyboardEventManager keyboardEventManager = new KeyboardEventManager();
         MouseEventManager mouseEventManager = new MouseEventManager();
-        Receiver receiver = new Receiver();
-        receiver.addBuffer(keyboardEventManager);
-        receiver.addBuffer(mouseEventManager);
         AtomicBoolean atomicBoolean = new AtomicBoolean(true);
-        Thread thread = startServer(receiver, atomicBoolean);
-        sendToServer(new EventGenerator().makeMouseOnlyEvent());
+        Thread thread = startServer(makeReceiver(keyboardEventManager, mouseEventManager), atomicBoolean);
 
+        sendToServer(new EventGenerator().makeMouseOnlyEvent());
         for (int i = 0; i < 3; i++) {
             if (mouseEventManager.getEvents().isEmpty()) {
                 try {
@@ -173,7 +179,10 @@ class SocketServerTest {
 
         atomicBoolean.set(false);
         try {
-            thread.join();
+            thread.join(100);
+            if (thread.isAlive()){
+                thread.interrupt();
+            }
         } catch (InterruptedException e) {
             e.printStackTrace();
             fail("Failed to join server thread: " + e.getMessage());
@@ -190,7 +199,10 @@ class SocketServerTest {
 
         atomicBoolean.set(false);
         try {
-            thread.join();
+            thread.join(100);
+            if (thread.isAlive()){
+                thread.interrupt();
+            }
         } catch (InterruptedException e) {
             e.printStackTrace();
             fail("Failed to join server thread: " + e.getMessage());


### PR DESCRIPTION
# No US related
	
## Description
Fixed socket server client connection bug

#### What did I do?

1. failing socket server tests
2. server socket to use direct connections
	  Updated ServerSocket to listen and handle a connection. It will keep
	  reading from that connection until the client disconnects. If there is
	  no data to read the server will wait 100ms and check again. 
	  The update was done accordingly with how screen is sending data which is
	  done trough a single client for the whole connection.

#### How did I do it?
By refactoring SocketServer into keeping a connection alive

#### Why did I do it?
Because screen is [using](https://github.com/Pending-Name-21/screen/pull/9/) a direct connection between sockets.

## Type of Change

- [ ] ✨ New Feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug Fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking Change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code Refactor
- [ ] ✅ Build Configuration Change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Pull Request Checklist

- [x] My commit messages are detailed.
- [x] My code follows the code style of this project.
- [x] No existing features have been broken without good reason.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
