### PR TITLE
Fixed socket server doesn't start

### DIFF
--- a/bridge/src/main/java/com/bridge/Game.java
+++ b/bridge/src/main/java/com/bridge/Game.java
@@ -66,13 +66,15 @@ public class Game {
         threadSocketServer = new Thread(socketServer);
         isServerRunning.set(true);
         threadSocketServer.start();
+
+        renderManager.init();
         gameInitializer.initializeSubscribers();
     }
 
     /**
      * Processes input by calling the check method on the input verifier.
      */
-    private void processInput() throws GameException {
+    private void processInput() {
         inputVerifier.check();
     }
 
@@ -90,7 +92,7 @@ public class Game {
         try {
             renderManager.render();
         } catch (RenderException e) {
-            LogHandler.log(Level.SEVERE, "Frames threshold has been reached", e);
+            LogHandler.log(Level.SEVERE, "Exception detected while attempting to render", e);
         }
     }
 

--- a/bridge/src/main/java/com/bridge/Game.java
+++ b/bridge/src/main/java/com/bridge/Game.java
@@ -30,7 +30,7 @@ public class Game {
     private final RenderManager renderManager;
     private final GameInitializer gameInitializer;
 
-    private final AtomicBoolean atomicBoolean;
+    private final AtomicBoolean isServerRunning;
     private final KeyboardEventManager keyboardEventManager;
     private final MouseEventManager mouseEventManager;
     private final SocketServer socketServer;
@@ -47,13 +47,13 @@ public class Game {
         this.updatePublisher = new UpdatePublisher();
         this.gameInitializer = new GameInitializer();
 
-        atomicBoolean = new AtomicBoolean();
+        isServerRunning = new AtomicBoolean();
         keyboardEventManager = new KeyboardEventManager();
         mouseEventManager = new MouseEventManager();
         Receiver receiver = new Receiver();
         receiver.addBuffer(keyboardEventManager);
         receiver.addBuffer(mouseEventManager);
-        socketServer = new SocketServer(new Receiver(), SocketServer.NAMESPACE, atomicBoolean);
+        socketServer = new SocketServer(new Receiver(), SocketServer.NAMESPACE, isServerRunning);
 
         inputVerifier = new InputVerifier(List.of(keyboardEventManager, mouseEventManager));
         renderManager = new RenderManager();
@@ -64,6 +64,7 @@ public class Game {
      */
     public void initialize() throws GameException {
         threadSocketServer = new Thread(socketServer);
+        isServerRunning.set(true);
         threadSocketServer.start();
         gameInitializer.initializeSubscribers();
     }
@@ -112,7 +113,8 @@ public class Game {
                 throw new RuntimeException(e);
             }
         }
-        atomicBoolean.set(false);
+
+        isServerRunning.set(false);
         try {
             threadSocketServer.join(1000);
             if (threadSocketServer.isAlive()) {

--- a/bridge/src/main/java/com/bridge/core/exceptions/ipc/SocketClientException.java
+++ b/bridge/src/main/java/com/bridge/core/exceptions/ipc/SocketClientException.java
@@ -1,0 +1,20 @@
+package com.bridge.core.exceptions.ipc;
+
+import com.bridge.core.exceptions.GameException;
+import java.util.logging.Level;
+
+public class SocketClientException extends GameException {
+
+    public SocketClientException(String message) {
+        super(message);
+    }
+
+    public SocketClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public Level getLogLevel() {
+        return Level.SEVERE;
+    }
+}

--- a/bridge/src/main/java/com/bridge/ipc/SocketClient.java
+++ b/bridge/src/main/java/com/bridge/ipc/SocketClient.java
@@ -1,12 +1,14 @@
 package com.bridge.ipc;
 
+import com.bridge.core.exceptions.ipc.SocketClientException;
 import com.bridge.core.exceptions.renderHandlerExceptions.RenderException;
 import com.bridge.core.handlers.LogHandler;
 import com.bridge.renderHandler.render.RenderManager;
 import java.io.IOException;
-import java.net.StandardProtocolFamily;
+import java.net.ConnectException;
 import java.net.UnixDomainSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Path;
 import java.util.logging.Level;
@@ -18,8 +20,7 @@ import java.util.logging.Level;
 public class SocketClient {
     public static final Path NAMESPACE =
             Path.of(System.getProperty("java.io.tmpdir"), "socket_console");
-
-    private SocketChannel channel;
+    private final Path namespace;
     private int failedWriteAttempts;
 
     /**
@@ -28,16 +29,7 @@ public class SocketClient {
      * @param namespace The name of the Unix domain socket to connect to.
      */
     public SocketClient(Path namespace) {
-        try {
-            channel = SocketChannel.open(StandardProtocolFamily.UNIX);
-            UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(namespace);
-            channel.connect(socketAddress);
-        } catch (IOException e) {
-            LogHandler.log(
-                    Level.WARNING,
-                    String.format("Could not connect to %s, trying again", namespace),
-                    e);
-        }
+        this.namespace = namespace;
     }
 
     /**
@@ -47,25 +39,52 @@ public class SocketClient {
      *
      * @param buffer The byte buffer containing the data to be sent.
      */
-    protected void send(ByteBuffer buffer) throws RenderException {
-        if (channel.isConnected()) {
-            while (buffer.hasRemaining()) {
-                try {
-                    channel.write(buffer);
-                    failedWriteAttempts = 0;
-                } catch (IOException e) {
-                    LogHandler.log(Level.SEVERE, "Frame has been lost!!!", e);
-                }
+    protected void send(ByteBuffer buffer) throws RenderException, SocketClientException {
+        UnixDomainSocketAddress serverAddress = UnixDomainSocketAddress.of(namespace);
+        try (SocketChannel channel = SocketChannel.open(serverAddress)) {
+            if (!channel.isConnected()) {
+                channel.connect(serverAddress);
             }
-        } else {
-            handleDisconnectedServer();
+
+            while (buffer.hasRemaining()) {
+                channel.write(buffer);
+                failedWriteAttempts = 0;
+            }
+
+        } catch (ConnectException | UnsupportedOperationException e) {
+            LogHandler.log(Level.WARNING, "Channel disconnected");
+            throw new SocketClientException("Channel disconnected");
+        } catch (ClosedChannelException e) {
+            LogHandler.log(Level.WARNING, "Could not send frame", e);
+            handleSentError();
+        } catch (IOException e) {
+            throw new RenderException("Unexpected exception", e);
         }
     }
 
-    private void handleDisconnectedServer() throws RenderException {
+    private void handleSentError() throws RenderException {
         failedWriteAttempts++;
         if (failedWriteAttempts >= RenderManager.FRAMES_LOST_THRESHOLD) {
+            failedWriteAttempts = 0;
             throw new RenderException("Reached frames lost threshold");
+        }
+    }
+
+    public static void scout() throws RenderException {
+        boolean success = false;
+        while (!success) {
+            try (SocketChannel ignored =
+                    SocketChannel.open(UnixDomainSocketAddress.of(NAMESPACE))) {
+                success = true;
+            } catch (IOException e) {
+                LogHandler.log(Level.WARNING, "Could not establish connection");
+            }
+
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                throw new RenderException(e.getMessage(), e);
+            }
         }
     }
 }

--- a/bridge/src/main/java/com/bridge/ipc/Transmitter.java
+++ b/bridge/src/main/java/com/bridge/ipc/Transmitter.java
@@ -1,6 +1,7 @@
 package com.bridge.ipc;
 
 import CoffeeTime.Output.Frame.*;
+import com.bridge.core.exceptions.ipc.SocketClientException;
 import com.bridge.core.exceptions.renderHandlerExceptions.RenderException;
 import com.google.flatbuffers.FlatBufferBuilder;
 import java.nio.ByteBuffer;
@@ -28,7 +29,8 @@ public class Transmitter {
      *
      * @param frame The rendering frame object containing sprites and sounds to transmit.
      */
-    public void send(com.bridge.renderHandler.render.Frame frame) throws RenderException {
+    public void send(com.bridge.renderHandler.render.Frame frame)
+            throws RenderException, SocketClientException {
         socketClient.send(handleFrame(frame));
     }
 

--- a/bridge/src/test/java/com/bridge/GameWithExceptionsTest.java
+++ b/bridge/src/test/java/com/bridge/GameWithExceptionsTest.java
@@ -6,6 +6,9 @@ import com.bridge.core.exceptions.GameException;
 import com.bridge.core.exceptions.initializerhandler.NotPossibleToInitializeSubscribersException;
 import com.bridge.gamesettings.AGameSettings;
 import com.bridge.initializerhandler.GameInitializer;
+import com.bridge.ipc.SocketClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +16,31 @@ class GameWithExceptionsTest {
     private TestGameSettings gameSettings;
     private Game game;
     private TestGameInitializer gameInitializer;
+    private static Thread SERVER_THREAD;
+
+    @BeforeAll
+    static void startServer() {
+        SocketServerMock.cleanup(SocketClient.NAMESPACE);
+        SERVER_THREAD = SocketServerMock.makeServerThread(SocketClient.NAMESPACE);
+        SERVER_THREAD.start();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            fail(e);
+        }
+    }
+
+    @AfterAll
+    static void stopServer() {
+        SERVER_THREAD.interrupt();
+        try {
+            SERVER_THREAD.join();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            fail("Failed to join server thread");
+        }
+        SocketServerMock.cleanup(SocketClient.NAMESPACE);
+    }
 
     @BeforeEach
     void setUp() throws GameException {

--- a/bridge/src/test/java/com/bridge/SocketServerMock.java
+++ b/bridge/src/test/java/com/bridge/SocketServerMock.java
@@ -1,0 +1,50 @@
+package com.bridge;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class SocketServerMock {
+    public static final Path NAMESPACE =
+            Path.of(System.getProperty("java.io.tmpdir"), "test_socket_console");
+
+    public static Thread makeServerThread(Path namespace) {
+        return new Thread(
+                () -> {
+                    UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(namespace);
+                    try (ServerSocketChannel server =
+                            ServerSocketChannel.open(StandardProtocolFamily.UNIX)) {
+                        server.bind(socketAddress);
+                        ByteBuffer buffer = ByteBuffer.allocate(1024);
+                        while (!Thread.currentThread().isInterrupted()) {
+                            try (SocketChannel client = server.accept()) {
+                                client.read(buffer);
+                                buffer.clear();
+                            } catch (IOException e) {
+                                if (Thread.currentThread().isInterrupted()) {
+                                    break;
+                                }
+                                fail("Server failed to accept connection", e);
+                            }
+                        }
+                    } catch (IOException e) {
+                        fail("Server failed to start", e);
+                    }
+                });
+    }
+
+    public static void cleanup(Path namespace) {
+        try {
+            Files.deleteIfExists(namespace);
+        } catch (IOException e) {
+            fail("Failed to delete namespace file", e);
+        }
+    }
+}

--- a/bridge/src/test/java/com/bridge/ipc/RenderManagerTest.java
+++ b/bridge/src/test/java/com/bridge/ipc/RenderManagerTest.java
@@ -2,21 +2,104 @@ package com.bridge.ipc;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.bridge.SocketServerMock;
 import com.bridge.core.exceptions.renderHandlerExceptions.RenderException;
 import com.bridge.renderHandler.render.RenderManager;
 import org.junit.jupiter.api.Test;
 
 public class RenderManagerTest {
+
     @Test
     void checkExceptionOnDisconnectedServer() {
         RenderManager renderManager = new RenderManager();
-        for (int i = 0; i < 60; i++) {
-            try {
-                renderManager.render();
-            } catch (RenderException e) {
-                assertInstanceOf(RenderException.class, e);
-                assertEquals(59, i);
-            }
+        try {
+            renderManager.render();
+        } catch (RenderException e) {
+            assertInstanceOf(RenderException.class, e);
         }
+    }
+
+    @Test
+    void checkScoutingDuringInit() {
+        SocketServerMock.cleanup(SocketClient.NAMESPACE);
+        Thread socketServer = SocketServerMock.makeServerThread(SocketClient.NAMESPACE);
+        socketServer.start();
+
+        RenderManager renderManager = new RenderManager();
+        try {
+            renderManager.init();
+            renderManager.render();
+        } catch (RenderException e) {
+            fail(e);
+        }
+
+        socketServer.interrupt();
+        try {
+            socketServer.join(100);
+        } catch (InterruptedException e) {
+            fail(e);
+        }
+        SocketServerMock.cleanup(SocketClient.NAMESPACE);
+    }
+
+    @Test
+    void checkScoutOnInterruptedServer() {
+        SocketServerMock.cleanup(SocketClient.NAMESPACE);
+        Thread socketServer = SocketServerMock.makeServerThread(SocketClient.NAMESPACE);
+        socketServer.start();
+        RenderManager renderManager = new RenderManager();
+        try {
+            renderManager.init();
+        } catch (RenderException e) {
+            fail(e);
+        }
+        Thread renderThread =
+                new Thread(
+                        () -> {
+                            while (true) {
+                                try {
+                                    renderManager.render();
+                                } catch (RenderException e) {
+                                    fail(e);
+                                }
+                                try {
+                                    Thread.sleep(10);
+                                } catch (InterruptedException e) {
+                                    fail(e);
+                                }
+                            }
+                        });
+        renderThread.start();
+
+        socketServer.interrupt();
+        try {
+            socketServer.join(100);
+        } catch (InterruptedException e) {
+            fail(e);
+        }
+        SocketServerMock.cleanup(SocketClient.NAMESPACE);
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            fail(e);
+        }
+
+        socketServer = SocketServerMock.makeServerThread(SocketServerMock.NAMESPACE);
+        renderThread.interrupt();
+        try {
+            renderThread.join(100);
+        } catch (InterruptedException e) {
+            fail(e);
+        }
+
+        socketServer.interrupt();
+        try {
+            socketServer.join(100);
+        } catch (InterruptedException e) {
+            fail(e);
+        }
+        SocketServerMock.cleanup(SocketClient.NAMESPACE);
+
+        assertFalse(renderThread.isAlive());
     }
 }


### PR DESCRIPTION
https://github.com/Pending-Name-21/frontend-library/issues/39

## Description

Fixed Games' isServerRunning flag, it was being instated as false, but now it's set to true.

Updated RenderManager to scout for a socket server before starting to send frames. This is done during the game initialization step.

## Type of Change

- [ ] ✨ New Feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug Fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking Change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code Refactor
- [ ] ✅ Build Configuration Change
- [ ] 📝 Documentation
- [x] 🗑️ Chore

## Pull Request Checklist

- [x] My commit messages are detailed.
- [x] My code follows the code style of this project.
- [x] No existing features have been broken without good reason.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
